### PR TITLE
Fix kube-vip README for metadata.yaml command

### DIFF
--- a/carvel-packages/kube-vip-package/README.md
+++ b/carvel-packages/kube-vip-package/README.md
@@ -5,7 +5,7 @@
 ## Installing as a direct Package
 1. apply the needed files
 ``` bash
-kubectl apply -n tanzu-package-repo-global -f ./metadata.yaml
+kubectl apply -n tanzu-package-repo-global -f metadata.yaml
 kubectl apply -n tanzu-package-repo-global -f package.yaml
 ```  
 2. Create a values file with your specific values


### PR DESCRIPTION
Closes: #3
Signed-off-by: William Lam <wlam@vmware.com>

`./` is causes error as its referencing the wrong path
